### PR TITLE
Ability to edit away embeds : V1

### DIFF
--- a/message.go
+++ b/message.go
@@ -10,6 +10,7 @@
 package discordgo
 
 import (
+	"encoding/json"
 	"io"
 	"regexp"
 	"strconv"

--- a/message.go
+++ b/message.go
@@ -121,11 +121,11 @@ type MessageSend struct {
 // MessageEdit is used to chain parameters via ChannelMessageEditComplex, which
 // is also where you should get the instance from.
 type MessageEdit struct {
-	Content *string       `json:"content,omitempty"`
-	Embed   *MessageEmbed `json:"embed,omitempty"`
+	Content   *string       	`json:"content,omitempty"`
+	EmbedEdit *NullableMessageEmbed `json:"embed,omitempty"`
 
-	ID      int64
-	Channel int64
+	ID        int64
+	Channel   int64
 }
 
 // NewMessageEdit returns a MessageEdit struct, initialized
@@ -147,7 +147,9 @@ func (m *MessageEdit) SetContent(str string) *MessageEdit {
 // SetEmbed is a convenience function for setting the embed,
 // so you can chain commands.
 func (m *MessageEdit) SetEmbed(embed *MessageEmbed) *MessageEdit {
-	m.Embed = embed
+	m.EmbedEdit = &NullableMessageEmbed { 
+			Embed : embed,
+	}
 	return m
 }
 
@@ -306,4 +308,17 @@ func (m *Message) ContentWithMoreMentionsReplaced(s *Session) (content string, e
 		return "#" + channel.Name
 	})
 	return
+}
+
+type NullableMessageEmbed struct {	
+	Embed *MessageEmbed `json:"embed,omitempty"`
+	Setnil bool
+}
+
+func (e NullableMessageEmbed) MarshalJSON() ([]byte, error) {
+	if e.Setnil == true {
+		return json.Marshal(nil)
+	}
+	
+	return json.Marshal(e.Embed)
 }

--- a/restapi.go
+++ b/restapi.go
@@ -1717,8 +1717,13 @@ func (s *Session) ChannelMessageEdit(channelID, messageID int64, content string)
 // ChannelMessageEditComplex edits an existing message, replacing it entirely with
 // the given MessageEdit struct
 func (s *Session) ChannelMessageEditComplex(m *MessageEdit) (st *Message, err error) {
-	if m.Embed != nil && m.Embed.Type == "" {
-		m.Embed.Type = "rich"
+	if m.EmbedEdit != nil {
+		if m.EmbedEdit.Embed != nil && m.EmbedEdit.Embed.Type == "" {
+			m.EmbedEdit.Embed.Type = "rich"
+		}
+		if m.EmbedEdit.Embed == nil && !m.EmbedEdit.Setnil { //dont reset embed unless Setnil is true
+			m.EmbedEdit = nil
+		} 
 	}
 
 	response, err := s.RequestWithBucketID("PATCH", EndpointChannelMessage(m.Channel, m.ID), m, EndpointChannelMessage(m.Channel, 0))


### PR DESCRIPTION
Proposal to add support to be able to completely remove Embeds during MessageEdit.

This is already supported by discord api, however the issue is, if MessageEdit.Embed is nil, nothing changes( field is omitted by Marshaller) and if empty MessageEmbed{} is passed , we get an empty embed. There is no way to completely remove embed from the message.

This method allows Embed to be completely removed provided Setnil flag is explicitly set to true. This helps in preserving current behavior while adding support to be able to completely edit away embeds. 