### PR TITLE
Allow resetting ChannelEdit ParentID

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/jonas747/gojay"
 	"github.com/pkg/errors"
+	"github.com/volatiletech/null"
 )
 
 // A Session represents a connection to the Discord API.
@@ -240,7 +241,7 @@ type ChannelEdit struct {
 	Bitrate              int                    `json:"bitrate,omitempty"`
 	UserLimit            int                    `json:"user_limit,omitempty"`
 	PermissionOverwrites []*PermissionOverwrite `json:"permission_overwrites,omitempty"`
-	ParentID             string                 `json:"parent_id,omitempty"`
+	ParentID             *null.String           `json:"parent_id,omitempty"`
 	RateLimitPerUser     *int                   `json:"rate_limit_per_user,omitempty"`
 }
 


### PR DESCRIPTION
here we need to use *null.String so that field is still omitted when not set. Setting Valid to false enables resetting the ParentID.
simple *string cannot be used because discord api doesnt support `""` in snowflake field. Sends error : `HTTP 400 Bad Request, {"parent_id": ["Value \"\" is not snowflake."]}`