### PR TITLE
Do not include Content-Type if body is null

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -141,7 +141,12 @@ func (s *Session) doRequestLockedBucket(method, urlStr, contentType string, b []
 		req.Header.Set("authorization", s.Token)
 	}
 
-	req.Header.Set("Content-Type", contentType)
+	// Discord's API returns a 400 Bad Request is Content-Type is set, but the
+	// request body is empty.
+	if b != nil {
+		req.Header.Set("Content-Type", contentType)
+	}
+	
 	// TODO: Make a configurable static variable.
 	req.Header.Set("User-Agent", fmt.Sprintf("DiscordBot (https://github.com/jonas747/discordgo, v%s)", VERSION))
 	req.Header.Set("X-RateLimit-Precision", "millisecond")


### PR DESCRIPTION
Content-Type in DELETE requests with null body causes the 400 Bad Request error.

Scheduled unbans are affected by this issue
```
level=error p=moderation msg="failed unbanning user" stck="moderation.punish:punishments.go:116" guild=631970473529573386 error="HTTP 400 Bad Request, {\"message\": \"400: Bad Request\", \"code\": 0}"
level=error p=scheduled_events msg="handler returned an error" stck="scheduledevents2.(*ScheduledEvents).check:scheduledevents.go:199" guild=631970473529573386 id=7509 error="HTTP 400 Bad Request, {\"message\": \"400: Bad Request\", \"code\": 0}"
```

Not including the Content-Type when body is null fixes the issue.
![image](https://user-images.githubusercontent.com/42714242/84878880-c1b40f80-b08a-11ea-823b-a0beaa192de5.png)
![image](https://user-images.githubusercontent.com/42714242/84879098-0d66b900-b08b-11ea-9b86-c456e02e3533.png)

See: https://github.com/bwmarrin/discordgo/commit/307c335eb6a184a754b15d05551a0f8336c46609#diff-1f514cd658bfa8ff1843f96bb4f41433
