### PR TITLE
Fix missing heartbeat lastSend

### DIFF
--- a/wsapi.go
+++ b/wsapi.go
@@ -174,6 +174,10 @@ func (wh *wsHeartBeater) Run(interval time.Duration) {
 }
 
 func (wh *wsHeartBeater) SendBeat() {
+	wh.Lock()
+	wh.lastSend = time.Now()
+	wh.Unlock()
+	
 	seq := atomic.LoadInt64(wh.sequence)
 
 	wh.writer.Queue(&outgoingEvent{


### PR DESCRIPTION
Currently heartbeat lastSend is never set and forever the default value. It is evident on [YAGPDB's status page](https://yagpdb.xyz/status), if you hover over a shard you'll see that last heartbeat is 292 years ago. This issue seems to have originated from 1e36e6c2937a999c676a53b2d54f00cea80e9633.