### PR TITLE
adding guild member avatar

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -35,6 +35,7 @@ var (
 	EndpointCDN             string
 	EndpointCDNAttachments  string
 	EndpointCDNAvatars      string
+	EndpointCDNGuilds       string
 	EndpointCDNIcons        string
 	EndpointCDNSplashes     string
 	EndpointCDNChannelIcons string
@@ -72,12 +73,14 @@ var (
 	EndpointUserConnections    = func(uID string) string { return "" }
 	EndpointUserNotes          = func(uID int64) string { return "" }
 
-	EndpointGuild           = func(gID int64) string { return "" }
-	EndpointGuildChannels   = func(gID int64) string { return "" }
-	EndpointGuildMembers    = func(gID int64) string { return "" }
-	EndpointGuildMember     = func(gID int64, uID int64) string { return "" }
-	EndpointGuildMemberMe   = func(gID int64) string { return "" }
-	EndpointGuildMemberRole = func(gID, uID, rID int64) string {
+	EndpointGuild                     = func(gID int64) string { return "" }
+	EndpointGuildChannels             = func(gID int64) string { return "" }
+	EndpointGuildMembers              = func(gID int64) string { return "" }
+	EndpointGuildMember               = func(gID int64, uID int64) string { return "" }
+	EndpointGuildMemberAvatar         = func(gID, uID int64, aID string) string { return "" }
+	EndpointGuildMemberAvatarAnimated = func(gID, uID int64, aID string) string { return "" }
+	EndpointGuildMemberMe             = func(gID int64) string { return "" }
+	EndpointGuildMemberRole           = func(gID, uID, rID int64) string {
 		return ""
 	}
 	EndpointGuildBans            = func(gID int64) string { return "" }
@@ -201,6 +204,7 @@ func CreateEndpoints(base string) {
 	EndpointCDN = "https://cdn.discordapp.com/"
 	EndpointCDNAttachments = EndpointCDN + "attachments/"
 	EndpointCDNAvatars = EndpointCDN + "avatars/"
+	EndpointCDNGuilds = EndpointCDN + "guilds/"
 	EndpointCDNIcons = EndpointCDN + "icons/"
 	EndpointCDNSplashes = EndpointCDN + "splashes/"
 	EndpointCDNChannelIcons = EndpointCDN + "channel-icons/"
@@ -242,6 +246,12 @@ func CreateEndpoints(base string) {
 	EndpointGuildChannels = func(gID int64) string { return EndpointGuilds + StrID(gID) + "/channels" }
 	EndpointGuildMembers = func(gID int64) string { return EndpointGuilds + StrID(gID) + "/members" }
 	EndpointGuildMember = func(gID int64, uID int64) string { return EndpointGuilds + StrID(gID) + "/members/" + StrID(uID) }
+	EndpointGuildMemberAvatar = func(gID, uID int64, aID string) string {
+		return EndpointCDNGuilds + StrID(gID) + "/users/" + StrID(uID) + "/avatars/" + aID + ".png"
+	}
+	EndpointGuildMemberAvatarAnimated = func(gID, uID int64, aID string) string {
+		return EndpointCDNGuilds + StrID(gID) + "/users/" + StrID(uID) + "/avatars/" + aID + ".gif"
+	}
 	EndpointGuildMemberMe = func(gID int64) string { return EndpointGuilds + StrID(gID) + "/members/@me" }
 	EndpointGuildMemberRole = func(gID, uID, rID int64) string {
 		return EndpointGuilds + StrID(gID) + "/members/" + StrID(uID) + "/roles/" + StrID(rID)

--- a/endpoints.go
+++ b/endpoints.go
@@ -246,10 +246,10 @@ func CreateEndpoints(base string) {
 	EndpointGuildChannels = func(gID int64) string { return EndpointGuilds + StrID(gID) + "/channels" }
 	EndpointGuildMembers = func(gID int64) string { return EndpointGuilds + StrID(gID) + "/members" }
 	EndpointGuildMember = func(gID int64, uID int64) string { return EndpointGuilds + StrID(gID) + "/members/" + StrID(uID) }
-	EndpointGuildMemberAvatar = func(gID, uID int64, aID string) string {
+	EndpointGuildMemberAvatar = func(gID int64, uID int64, aID string) string {
 		return EndpointCDNGuilds + StrID(gID) + "/users/" + StrID(uID) + "/avatars/" + aID + ".png"
 	}
-	EndpointGuildMemberAvatarAnimated = func(gID, uID int64, aID string) string {
+	EndpointGuildMemberAvatarAnimated = func(gID int64, uID int64, aID string) string {
 		return EndpointCDNGuilds + StrID(gID) + "/users/" + StrID(uID) + "/avatars/" + aID + ".gif"
 	}
 	EndpointGuildMemberMe = func(gID int64) string { return EndpointGuilds + StrID(gID) + "/members/@me" }

--- a/structs.go
+++ b/structs.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -749,6 +750,9 @@ type Member struct {
 	// The nickname of the member, if they have one.
 	Nick string `json:"nick"`
 
+	// The guild avatar hash of the member, if they have one.
+	Avatar string `json:"avatar"`
+
 	// Whether the member is deafened at a guild level.
 	Deaf bool `json:"deaf"`
 
@@ -764,6 +768,24 @@ type Member struct {
 
 func (m *Member) GetGuildID() int64 {
 	return m.GuildID
+}
+
+func (m *Member) AvatarURL(size string) string {
+	var URL string
+	u := m.User
+
+	if m.Avatar == "" {
+		return URL
+	} else if strings.HasPrefix(m.Avatar, "a_") {
+		URL = EndpointGuildMemberAvatarAnimated(m.GuildID, u.ID, m.Avatar)
+	} else {
+		URL = EndpointGuildMemberAvatar(m.GuildID, u.ID, m.Avatar)
+	}
+
+	if size != "" {
+		return URL + "?size=" + size
+	}
+	return URL
 }
 
 // A Settings stores data for a specific users Discord client settings.


### PR DESCRIPTION
with the addition of guild-specific avatars, the member struct now has `avatar`. This PR makes the following additions:
- Adding a new `guilds` CDN endpoint.
- Adding two new funcs, `EndpointGuildMemberAvatarAnimated` and `EndpointGuildMemberAvatar`.
- Making additions to the Member struct.
- An `AvatarURL` func for member.