### PR TITLE
member avatar fixes and minor changes

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -772,10 +772,15 @@ func (m *Member) GetGuildID() int64 {
 
 func (m *Member) AvatarURL(size string) string {
 	var URL string
+
+	if m == nil {
+		return "Member not found"
+	}
+
 	u := m.User
 
 	if m.Avatar == "" {
-		return URL
+		return u.AvatarURL(size)
 	} else if strings.HasPrefix(m.Avatar, "a_") {
 		URL = EndpointGuildMemberAvatarAnimated(m.GuildID, u.ID, m.Avatar)
 	} else {


### PR DESCRIPTION
This PR makes the following changes:
- added a check for nil member
- in case a user has no guild member avatar, returns user avatar instead of an empty string

Thanks to @mrbentarikau for suggesting the changes and letting me use their discordgo and dstate forks as a reference. 