### PR TITLE
Add Pending in Member struct

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -760,6 +760,9 @@ type Member struct {
 
 	// A list of IDs of the roles which are possessed by the member.
 	Roles IDSlice `json:"roles,string"`
+
+	// Whether the user has not yet passed the guild's Membership Screening requirements
+	Pending bool `json:"pending"`
 }
 
 func (m *Member) GetGuildID() int64 {


### PR DESCRIPTION
Pending flag tells whether the user has not yet passed the guild's [Membership Screening (https://discord.com/developers/docs/resources/guild#membership-screening-object) requirements

Adding this in Member struct, so as to compare current Member's pending with the state's to know if a member has completed Membership screening.